### PR TITLE
feat: add MiniMax as a named LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,26 @@
 # Codebase Analysis Agent - Configuration Template
 # Copy this file to .env and fill in your actual values
 
-# OpenRouter API credentials
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Supported providers: "openrouter" (default), "minimax", "custom"
+LLM_PROVIDER=openrouter
+
+# ── OpenRouter (default) ──────────────────────────────────────────────────────
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 MODEL_NAME=google/gemini-2.5-flash-lite-preview-06-17
+
+# ── MiniMax ───────────────────────────────────────────────────────────────────
+# To use MiniMax, set LLM_PROVIDER=minimax and provide your API key.
+# Available models: MiniMax-M2.5 (default), MiniMax-M2.5-highspeed
+# Context window: 204,800 tokens
+# MINIMAX_API_KEY=your_minimax_api_key_here
+# MODEL_NAME=MiniMax-M2.5
+
+# ── Generic overrides (any provider) ──────────────────────────────────────────
+# These override the provider preset if set:
+# LLM_API_KEY=your_api_key_here
+# LLM_BASE_URL=https://your-custom-endpoint/v1
 
 # Flask server configuration
 FLASK_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A terminal-styled AI agent that analyzes any GitHub repository and answers quest
 
 ## Tech Stack
 
-- **LLM**: Configurable via `.env` (default: `google/gemini-2.5-flash-lite` via OpenRouter)
+- **LLM**: Multi-provider support — [OpenRouter](https://openrouter.ai/) (default), [MiniMax](https://www.minimaxi.com/), or any OpenAI-compatible endpoint
 - **Backend**: Python + Flask with Server-Sent Events (SSE) for streaming
 - **Analysis**: Parallel map-reduce chunking with token-aware hierarchical reduction
 - **Frontend**: Terminal-styled dark web UI
@@ -53,7 +53,7 @@ pip install -r requirements.txt
 
 ```bash
 cp .env.example .env
-# Edit .env and add your OpenRouter API key
+# Edit .env and add your API key (see "Supported Providers" below)
 ```
 
 ### 4. Run the server
@@ -77,14 +77,54 @@ All configuration is done via `.env` (see `.env.example`):
 
 | Variable | Description | Default |
 |---|---|---|
-| `OPENROUTER_API_KEY` | Your OpenRouter API key | *(required)* |
-| `OPENROUTER_BASE_URL` | OpenRouter API base URL | `https://openrouter.ai/api/v1` |
-| `MODEL_NAME` | LLM model to use | `google/gemini-2.5-flash-lite-preview-06-17` |
+| `LLM_PROVIDER` | Provider preset: `openrouter`, `minimax`, or `custom` | `openrouter` |
+| `OPENROUTER_API_KEY` | OpenRouter API key (when using OpenRouter) | *(required for openrouter)* |
+| `MINIMAX_API_KEY` | MiniMax API key (when using MiniMax) | *(required for minimax)* |
+| `MODEL_NAME` | LLM model to use | Provider-dependent |
+| `LLM_BASE_URL` | Override base URL for any provider | Provider-dependent |
+| `LLM_API_KEY` | Override API key for any provider | Provider-dependent |
 | `FLASK_HOST` | Server bind host | `0.0.0.0` |
 | `FLASK_PORT` | Server port | `5000` |
 | `GITHUB_CLONE_BASE` | Temp dir for cloned repos | `/tmp/codebase_agent_repos` |
 
-You can swap in any OpenRouter-compatible model by changing `MODEL_NAME` in `.env` — the UI reflects the active model dynamically.
+### Supported Providers
+
+#### OpenRouter (default)
+
+```bash
+LLM_PROVIDER=openrouter
+OPENROUTER_API_KEY=your_key_here
+MODEL_NAME=google/gemini-2.5-flash-lite   # or any OpenRouter model
+```
+
+#### MiniMax
+
+[MiniMax](https://www.minimaxi.com/) offers high-performance models with a 204K token context window — ideal for analyzing large codebases in fewer chunks.
+
+```bash
+LLM_PROVIDER=minimax
+MINIMAX_API_KEY=your_key_here
+# MODEL_NAME=MiniMax-M2.5              # default — peak performance, best value
+# MODEL_NAME=MiniMax-M2.5-highspeed    # same performance, faster
+```
+
+| Model | Context Window | Input Price | Output Price |
+|---|---|---|---|
+| `MiniMax-M2.5` | 204,800 tokens | $0.3/M tokens | $1.2/M tokens |
+| `MiniMax-M2.5-highspeed` | 204,800 tokens | $0.6/M tokens | $2.4/M tokens |
+
+Get your API key at [platform.minimax.io](https://platform.minimax.io/).
+
+#### Custom Provider
+
+Any OpenAI-compatible endpoint can be used:
+
+```bash
+LLM_PROVIDER=custom
+LLM_API_KEY=your_key_here
+LLM_BASE_URL=https://your-endpoint/v1
+MODEL_NAME=your-model-name
+```
 
 ## Architecture
 

--- a/agent.py
+++ b/agent.py
@@ -1,18 +1,20 @@
 """
 agent.py - AI-powered codebase analysis agent.
 
-Uses the OpenRouter API with Gemini 2.5 Flash Lite to analyze project codebases,
-generate comprehensive reports, and answer follow-up questions in a stateful
+Uses a configurable LLM provider to analyze project codebases, generate
+comprehensive reports, and answer follow-up questions in a stateful
 multi-turn conversation.
+
+Supported providers:
+  - **openrouter** (default): OpenRouter API with any compatible model
+  - **minimax**: MiniMax API (OpenAI-compatible) with MiniMax-M2.5 models
+  - **custom**: Any OpenAI-compatible endpoint via manual configuration
 
 Configuration is loaded from a .env file via python-dotenv.
 
 Context-limit enforcement
 -------------------------
-Gemini 2.5 Flash Lite (via OpenRouter) has a hard limit of 1,048,576 tokens per
-request.  For large codebases the raw code_contents can far exceed this limit.
-
-The agent enforces the limit with a two-stage strategy:
+The agent enforces context limits with a two-stage strategy:
 
 1. **Fit-in-one** – if the full prompt (system + user) fits within
 MAX_PROMPT_TOKENS, it is sent as a single request (original behaviour).
@@ -70,21 +72,67 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# OpenRouter configuration — loaded from .env
-OPENROUTER_API_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
-MODEL_NAME = os.getenv("MODEL_NAME", "google/gemini-2.5-flash-lite")
+# ── Provider configuration ─────────────────────────────────────────────────────
+# LLM_PROVIDER selects a named preset: "openrouter" (default), "minimax", or
+# "custom".  Each preset defines sensible defaults for base URL, API key env
+# variable, model name, and context window size.  All values can still be
+# overridden individually via the corresponding env vars.
+
+PROVIDER_PRESETS = {
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "default_model": "google/gemini-2.5-flash-lite",
+        "context_limit": 131_072,
+        "api_max_tokens": 1_048_576,
+    },
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1",
+        "api_key_env": "MINIMAX_API_KEY",
+        "default_model": "MiniMax-M2.5",
+        "context_limit": 204_800,
+        "api_max_tokens": 204_800,
+    },
+    "custom": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "default_model": "google/gemini-2.5-flash-lite",
+        "context_limit": 131_072,
+        "api_max_tokens": 1_048_576,
+    },
+}
+
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openrouter").lower()
+if LLM_PROVIDER not in PROVIDER_PRESETS:
+    logger.warning("Unknown LLM_PROVIDER '%s', falling back to 'openrouter'.", LLM_PROVIDER)
+    LLM_PROVIDER = "openrouter"
+
+_preset = PROVIDER_PRESETS[LLM_PROVIDER]
+
+# Resolve final configuration: env var overrides take precedence over presets.
+# For backward compatibility, OPENROUTER_BASE_URL / OPENROUTER_API_KEY are
+# always checked as fallback env vars regardless of the selected provider.
+LLM_BASE_URL = (
+    os.getenv("LLM_BASE_URL")
+    or os.getenv("OPENROUTER_BASE_URL")
+    or _preset["base_url"]
+)
+LLM_API_KEY = (
+    os.getenv("LLM_API_KEY")
+    or os.getenv(_preset["api_key_env"])
+    or os.getenv("OPENROUTER_API_KEY", "")
+)
+MODEL_NAME = os.getenv("MODEL_NAME") or _preset["default_model"]
+
+# Backward-compatible aliases
+OPENROUTER_API_URL = LLM_BASE_URL
+OPENROUTER_API_KEY = LLM_API_KEY
 
 # ── Token-limit constants ──────────────────────────────────────────────────────
-# Hard API limit for Gemini 2.5 Flash Lite via OpenRouter.
-API_MAX_TOKENS: int = 1_048_576
+API_MAX_TOKENS: int = _preset["api_max_tokens"]
 
-# Hard limit for 128K context window models (e.g. gpt-oss-20b).
-# Used to compute a dynamic per-chunk code budget that accounts for the
-# actual MAP_CHUNK_PROMPT overhead (system prompt + directory tree + template).
-# The dynamic budget is computed in analyze_project_stream() before chunking.
-# This constant is the fallback / default when no dynamic computation is done.
-MODEL_CONTEXT_LIMIT: int = 131_072    # hard limit for 128K models
+# Context window size — varies by provider/model.
+MODEL_CONTEXT_LIMIT: int = _preset["context_limit"]
 
 # We reserve headroom for the system prompt, prompt template boilerplate, and
 # the model's own output budget.  The remaining budget is available for code.
@@ -300,30 +348,37 @@ class CodebaseAnalysisAgent:
 
     def __init__(self, api_key: Optional[str] = None):
         """
-        Initialize the agent with OpenRouter API credentials.
+        Initialize the agent with LLM provider credentials.
 
         Credentials are resolved in this order:
         1. Explicit api_key argument
-        2. OPENROUTER_API_KEY environment variable (loaded from .env)
+        2. Provider-specific env var (e.g. MINIMAX_API_KEY, OPENROUTER_API_KEY)
+        3. LLM_API_KEY env var (generic override)
 
         Args:
-            api_key: Optional override for the OpenRouter API key.
+            api_key: Optional override for the LLM API key.
         """
-        resolved_key = api_key or OPENROUTER_API_KEY
+        resolved_key = api_key or LLM_API_KEY
         if not resolved_key:
+            key_env = _preset["api_key_env"]
             raise ValueError(
-                "OpenRouter API key not found. Set OPENROUTER_API_KEY in .env or pass api_key."
+                f"LLM API key not found. Set {key_env} in .env or pass api_key. "
+                f"(Current provider: {LLM_PROVIDER})"
             )
 
         self.client = OpenAI(
-            base_url=OPENROUTER_API_URL,
+            base_url=LLM_BASE_URL,
             api_key=resolved_key,
         )
         self.model = MODEL_NAME
+        self.provider = LLM_PROVIDER
         self.conversation_history: list[dict] = []
         self.project_path: Optional[str] = None
         self.scan_result: Optional[dict] = None
-        logger.info("CodebaseAnalysisAgent initialized with model: %s", self.model)
+        logger.info(
+            "CodebaseAnalysisAgent initialized with provider=%s, model=%s, base_url=%s",
+            self.provider, self.model, LLM_BASE_URL,
+        )
 
     def _call_llm(self, messages: list[dict]) -> str:
         """
@@ -352,10 +407,11 @@ class CodebaseAnalysisAgent:
         logger.debug("Pre-flight token estimate: ~%d tokens", estimated)
 
         try:
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-            )
+            kwargs = dict(model=self.model, messages=messages)
+            # MiniMax requires temperature in (0.0, 1.0] — zero is rejected.
+            if self.provider == "minimax":
+                kwargs["temperature"] = 1.0
+            response = self.client.chat.completions.create(**kwargs)
             return response.choices[0].message.content
         except Exception as e:
             logger.error("LLM API call failed: %s", e)

--- a/app.py
+++ b/app.py
@@ -400,9 +400,13 @@ def get_config():
     Return public runtime configuration for the frontend.
 
     Returns:
-        JSON with 'model' key reflecting the active MODEL_NAME from .env.
+        JSON with 'model' and 'provider' keys reflecting the active configuration.
     """
-    return jsonify({"model": os.getenv("MODEL_NAME", "google/gemini-2.5-flash-lite")})
+    from agent import LLM_PROVIDER, MODEL_NAME as ACTIVE_MODEL
+    return jsonify({
+        "model": ACTIVE_MODEL,
+        "provider": LLM_PROVIDER,
+    })
 
 
 @app.route("/health")


### PR DESCRIPTION
## Summary

- Add multi-provider support with named presets: **OpenRouter** (default), **MiniMax**, and **custom** OpenAI-compatible endpoints
- MiniMax models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`) offer a 204K token context window, reducing chunking overhead for large codebases
- Full backward compatibility — existing OpenRouter configs continue to work without changes

## Changes

| File | What changed |
|---|---|
| `agent.py` | Added `PROVIDER_PRESETS` config system with `LLM_PROVIDER` env var; handles MiniMax temperature constraint (must be >0, defaults to 1.0) |
| `app.py` | `/api/config` now returns the active provider name alongside the model |
| `.env.example` | Added MiniMax and generic override configuration sections |
| `README.md` | Documented all three providers with setup instructions and MiniMax pricing table |

## How to use MiniMax

```bash
# In .env:
LLM_PROVIDER=minimax
MINIMAX_API_KEY=your_key_here
# MODEL_NAME=MiniMax-M2.5          # default
# MODEL_NAME=MiniMax-M2.5-highspeed  # faster variant
```

Get an API key at [platform.minimax.io](https://platform.minimax.io/).

## Test plan

- [x] Python syntax check passes
- [x] Default provider (openrouter) configuration unchanged
- [x] MiniMax provider resolves correct base URL, model, and context limit
- [x] MiniMax API integration test: successfully analyzed a codebase with `MiniMax-M2.5`
- [x] Temperature constraint enforced (MiniMax rejects 0, defaults to 1.0)
- [x] Backward compatibility: existing env vars still work