### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,10 @@ MODEL_NAME=google/gemini-2.5-flash-lite-preview-06-17
 
 # ── MiniMax ───────────────────────────────────────────────────────────────────
 # To use MiniMax, set LLM_PROVIDER=minimax and provide your API key.
-# Available models: MiniMax-M2.5 (default), MiniMax-M2.5-highspeed
+# Available models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 # Context window: 204,800 tokens
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MODEL_NAME=MiniMax-M2.5
+# MODEL_NAME=MiniMax-M2.7
 
 # ── Generic overrides (any provider) ──────────────────────────────────────────
 # These override the provider preset if set:

--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ MODEL_NAME=google/gemini-2.5-flash-lite   # or any OpenRouter model
 ```bash
 LLM_PROVIDER=minimax
 MINIMAX_API_KEY=your_key_here
-# MODEL_NAME=MiniMax-M2.5              # default — peak performance, best value
-# MODEL_NAME=MiniMax-M2.5-highspeed    # same performance, faster
+# MODEL_NAME=MiniMax-M2.7              # default — latest flagship, enhanced reasoning
+# MODEL_NAME=MiniMax-M2.7-highspeed    # high-speed version for low-latency scenarios
+# MODEL_NAME=MiniMax-M2.5              # previous generation
+# MODEL_NAME=MiniMax-M2.5-highspeed    # previous generation, high-speed
 ```
 
 | Model | Context Window | Input Price | Output Price |
 |---|---|---|---|
+| `MiniMax-M2.7` | 204,800 tokens | $0.3/M tokens | $1.2/M tokens |
+| `MiniMax-M2.7-highspeed` | 204,800 tokens | $0.6/M tokens | $2.4/M tokens |
 | `MiniMax-M2.5` | 204,800 tokens | $0.3/M tokens | $1.2/M tokens |
 | `MiniMax-M2.5-highspeed` | 204,800 tokens | $0.6/M tokens | $2.4/M tokens |
 

--- a/agent.py
+++ b/agent.py
@@ -7,7 +7,7 @@ multi-turn conversation.
 
 Supported providers:
   - **openrouter** (default): OpenRouter API with any compatible model
-  - **minimax**: MiniMax API (OpenAI-compatible) with MiniMax-M2.5 models
+  - **minimax**: MiniMax API (OpenAI-compatible) with MiniMax-M2.7 models
   - **custom**: Any OpenAI-compatible endpoint via manual configuration
 
 Configuration is loaded from a .env file via python-dotenv.
@@ -89,7 +89,7 @@ PROVIDER_PRESETS = {
     "minimax": {
         "base_url": "https://api.minimax.io/v1",
         "api_key_env": "MINIMAX_API_KEY",
-        "default_model": "MiniMax-M2.5",
+        "default_model": "MiniMax-M2.7",
         "context_limit": 204_800,
         "api_max_tokens": 204_800,
     },


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to include the latest M2.7 model as default.

## Changes

- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to the model selection list
- Set `MiniMax-M2.7` as the new default model
- Retain all previous models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`) as available alternatives
- Update documentation and configuration template

## Why

MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. This upgrade keeps the project aligned with the newest available models while maintaining backward compatibility.

## Testing

- Verified `PROVIDER_PRESETS["minimax"]["default_model"]` resolves to `MiniMax-M2.7`
- Integration tested with MiniMax API — M2.7 model responds correctly
- All existing provider presets and temperature clamping logic unchanged