### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,23 +99,21 @@ MODEL_NAME=google/gemini-2.5-flash-lite   # or any OpenRouter model
 
 #### MiniMax
 
-[MiniMax](https://www.minimaxi.com/) offers high-performance models with a 204K token context window — ideal for analyzing large codebases in fewer chunks.
+[MiniMax](https://www.minimaxi.com/) offers high-performance models with a 512K token context window — ideal for analyzing large codebases in fewer chunks.
 
 ```bash
 LLM_PROVIDER=minimax
 MINIMAX_API_KEY=your_key_here
-# MODEL_NAME=MiniMax-M2.7              # default — latest flagship, enhanced reasoning
-# MODEL_NAME=MiniMax-M2.7-highspeed    # high-speed version for low-latency scenarios
-# MODEL_NAME=MiniMax-M2.5              # previous generation
-# MODEL_NAME=MiniMax-M2.5-highspeed    # previous generation, high-speed
+# MODEL_NAME=MiniMax-M3                # default — latest flagship, enhanced reasoning
+# MODEL_NAME=MiniMax-M2.7              # previous generation
+# MODEL_NAME=MiniMax-M2.7-highspeed    # previous generation, high-speed
 ```
 
 | Model | Context Window | Input Price | Output Price |
 |---|---|---|---|
+| `MiniMax-M3` | 524,288 tokens | $0.6/M tokens | $2.4/M tokens |
 | `MiniMax-M2.7` | 204,800 tokens | $0.3/M tokens | $1.2/M tokens |
 | `MiniMax-M2.7-highspeed` | 204,800 tokens | $0.6/M tokens | $2.4/M tokens |
-| `MiniMax-M2.5` | 204,800 tokens | $0.3/M tokens | $1.2/M tokens |
-| `MiniMax-M2.5-highspeed` | 204,800 tokens | $0.6/M tokens | $2.4/M tokens |
 
 Get your API key at [platform.minimax.io](https://platform.minimax.io/).
 

--- a/agent.py
+++ b/agent.py
@@ -7,7 +7,7 @@ multi-turn conversation.
 
 Supported providers:
   - **openrouter** (default): OpenRouter API with any compatible model
-  - **minimax**: MiniMax API (OpenAI-compatible) with MiniMax-M2.7 models
+  - **minimax**: MiniMax API (OpenAI-compatible) with MiniMax-M3 models
   - **custom**: Any OpenAI-compatible endpoint via manual configuration
 
 Configuration is loaded from a .env file via python-dotenv.
@@ -89,9 +89,9 @@ PROVIDER_PRESETS = {
     "minimax": {
         "base_url": "https://api.minimax.io/v1",
         "api_key_env": "MINIMAX_API_KEY",
-        "default_model": "MiniMax-M2.7",
-        "context_limit": 204_800,
-        "api_max_tokens": 204_800,
+        "default_model": "MiniMax-M3",
+        "context_limit": 524_288,
+        "api_max_tokens": 128_000,
     },
     "custom": {
         "base_url": "https://openrouter.ai/api/v1",


### PR DESCRIPTION
## Summary
Upgrade MiniMax provider configuration to use MiniMax-M3 as the default model.

## Changes
- Set `MiniMax-M3` as the default model for the `minimax` provider preset
- Update `context_limit` to 524,288 and `api_max_tokens` to 128,000 to match M3 capabilities
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as documented alternatives
- Remove references to the older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` models
- Update the module docstring to reflect the new default
- Update README provider section: 512K context, model table re-ordered with M3 first

## Why
MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K max output, and image input support — a meaningful upgrade for analyzing large codebases in fewer chunks.

## Testing
- `python3 -c "import ast; ast.parse(open('agent.py').read())"` passes
- No existing unit tests in this repo